### PR TITLE
Add Next.js-specific check

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,15 @@ class PrebuildWebpackPlugin {
           return this.build(compiler, compilation, matchedFiles);
         }
 
+        // Next.js-specific Optimization
+        // As documented here: https://nextjs.org/docs#customizing-webpack-config
+        // Next.js executes webpack twice, once for the server, and once for the client
+        // To prevent doing work 2x, we choose (arbitrarily) the 'client' run,
+        // immediately returning on anything else
+        if (compilation.name && compilation.name !== "client") {
+          return Promise.resolve();
+        }
+
         if (!this.files.pattern) return Promise.resolve();
 
         const changedFile = this.getChangedFile(compiler);


### PR DESCRIPTION
* Prevent 2x work by checking `compilation.name`

*Note*: This was in the original (non-extracted) implementation here: https://github.com/hashicorp/next-mdx-enhanced/blob/1cf90646c05d7754c84743c461d2c81064a9ce1c/plugin.js#L27-L30

Might be worth considering a "nicer" abstraction where non-Next.js consumers wouldn't be bothered by these specific details.