### PR TITLE
Terminology update: cache to memoize

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A function that's called **each time webpack rebuilds** in dev mode. If `files.p
 | `options`                | `object`  | All valid object properties are documented [here](https://github.com/isaacs/node-glob#option).                                           |
 | `addFilesAsDependencies` | `boolean` | Flag indicating whether or not to explicitly add matched files to webpack's dependency tree.                                             |
 
-### clearCacheOnUpdate
+### clearMemoOnUpdate
 
 > `boolean` | optional | default: `false`
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -28,7 +28,7 @@ describe('PrebuildWebpackPlugin', () => {
       compiler.run(async (err, stats) => {
         if (err) return done(err)
         const matchedFiles = await stats.compilation.options.plugins[0]
-          .matchedFilesCache
+          .matchedFilesMemo
         expect(matchedFiles).toStrictEqual(undefined)
         done()
       })
@@ -51,7 +51,7 @@ describe('PrebuildWebpackPlugin', () => {
       compiler.run(async (err, stats) => {
         if (err) return done(err)
         const matchedFiles = await stats.compilation.options.plugins[0]
-          .matchedFilesCache
+          .matchedFilesMemo
         expect(matchedFiles.length).toBe(3)
         done()
       })


### PR DESCRIPTION
The proper term for what we're doing with the `getMatchedFiles` results is memoization, not caching. This PR updates the terminology appropriately. It is breaking because of the option name change.