### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:latest
+      - image: docker.mirror.hashicorp.services/circleci/node:latest
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, relevant parts of Makefiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own! 